### PR TITLE
Remove void return type from `FixCommand::validateOptions()`

### DIFF
--- a/src/Console/FixCommand.php
+++ b/src/Console/FixCommand.php
@@ -217,7 +217,7 @@ class FixCommand extends Command
         return $resolver;
     }
 
-    protected function validateOptions(): void
+    protected function validateOptions()
     {
         if (null !== $this->option('config') && null !== $this->option('rules')) {
             if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {


### PR DESCRIPTION
Void return type was added PHP 7.1 whereas all documentation suggests backward compatibility with PHP 7.0