### PR TITLE
Verbosity level is not working

### DIFF
--- a/src/Console/FixCommand.php
+++ b/src/Console/FixCommand.php
@@ -185,7 +185,7 @@ class FixCommand extends Command
                 'diff' => $this->option('diff'),
                 'diff-format' => $this->option('diff-format'),
                 'stop-on-violation' => $this->option('stop-on-violation'),
-                'verbosity' => $this->verbosity,
+                'verbosity' => $this->getOutput()->getVerbosity(),
                 'show-progress' => $this->option('show-progress'),
             ],
             getcwd(),


### PR DESCRIPTION
The command gives the same result as without the verbosity:

`php artisan fixer:fix --show-progress=dots -v`

This is because the verbosity is set by default, but not from the output.